### PR TITLE
Update organizational references from Code for America to ACT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Jekyll-based static website for Code For Dayton (codefordayton.org), a local civic hacking group in Dayton, Ohio aligned with the Alliance of Civic Technologists (https://www.civictechnologists.org/). The site is hosted via GitHub Pages and automatically deploys when changes are pushed to the `main` branch.
+
+## Architecture
+
+### Key Technologies
+- **Jekyll 3.9.3**: Static site generator using Ruby
+- **GitHub Pages**: Hosting platform with automatic deployment
+- **Sass**: CSS preprocessing (located in `_sass/`)
+- **Kramdown**: Markdown processor
+
+### Directory Structure
+- `_data/`: YAML data files that drive site content
+  - `events/active.yml`: Current events listings
+  - `projects/active.yml` & `projects/inactive.yml`: Project listings
+  - `team.yml`: Team member information
+- `_posts/`: Blog posts in Markdown format
+- `_layouts/`: HTML templates (default, page, post)
+- `_includes/`: Reusable HTML components
+- `_sass/`: Sass stylesheets organized by component
+- `_site/`: Generated static site (build output)
+
+### Content Management
+The site uses Jekyll's data-driven approach where YAML files in `_data/` populate lists and content sections. This allows non-technical contributors to update events, projects, and team information without touching HTML.
+
+## Development Commands
+
+### Local Development
+```bash
+# Install dependencies
+gem install jekyll jekyll-redirect-from
+
+# Build the site
+jekyll build
+
+# Serve locally with live reload
+jekyll serve --livereload
+# Site will be available at http://127.0.0.1:4000/
+```
+
+### Dependencies
+- Ruby (available in system PATH)
+- Jekyll gem and jekyll-redirect-from plugin
+- System dependencies may include gcc-c++, redhat-rpm-config, ruby-devel (on Fedora)
+
+## Deployment
+
+The site automatically deploys to https://www.codefordayton.org/ when changes are pushed to the `main` branch. No manual deployment process is required.
+
+## Content Updates
+
+- **Events**: Edit `_data/events/active.yml`
+- **Active Projects**: Edit `_data/projects/active.yml`
+- **Retired Projects**: Edit `_data/projects/inactive.yml`
+- **Team Members**: Edit `_data/team.yml`
+- **Blog Posts**: Add new files to `_posts/` following the naming convention `YYYY-MM-DD-title.md`
+- **Pages**: Edit HTML/Markdown files in the root directory or create new ones
+
+## Configuration
+
+Site configuration is managed in `_config.yml` including:
+- Site metadata and social links
+- Jekyll plugins (jekyll-redirect-from, jekyll-feed)
+- Collection settings for posts and uploads
+- Base URL and author information

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ collections:
     output: true
 email: team@codefordayton.org
 description:
-  'Part of the Code for America Brigade network, we are a volunteer group
+  'Part of the Alliance of Civic Technologists (ACT) network, we are a volunteer group
   of developers, designers, data geeks, and citizen activists who use creative technology
   to solve civic and social problems.'
 baseurl: ''

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -35,7 +35,7 @@ This policy is based on several other policies, including the Ohio LinuxFest ant
 
 All Code for Dayton network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.
 
-In addition to governing our own events by this policy, Code for Dayton will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
+In addition to governing our own events by this policy, Code for Dayton will only lend our brand and fund groups that offer an anti-harassment policy to their attendees.
 
 Code for Dayton is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for Dayton event or network activity, including talks. Anyone in violation of these policies may be expelled from Code for Dayton network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -6,7 +6,7 @@ layout: page
 {: .t-section-headline }
 # Privacy Policy
 
-CodeforDayton.org is a nonprofit website run by volunteers from Code for Dayton, which is fiscally sponsored by Code for America Labs, Inc. This Privacy Policy describes how we collect, use, and protect your personal information on our websites, including the Code for Dayton website. By submitting your personal information on our websites, you agree to the terms in this Privacy Policy. If you do not agree with these terms, please do not use our websites.
+CodeforDayton.org is a nonprofit website run by volunteers from Code for Dayton, a local civic hacking group fiscally sponsored by Hack Club Bank. This Privacy Policy describes how we collect, use, and protect your personal information on our websites, including the Code for Dayton website. By submitting your personal information on our websites, you agree to the terms in this Privacy Policy. If you do not agree with these terms, please do not use our websites.
 
 ### Overview
 We collect information from you when you visit and take actions on our website. We use this information to provide the services you’ve requested.

--- a/projects.html
+++ b/projects.html
@@ -136,7 +136,7 @@ type: inNavBar
 
       <li>The project must solve a <strong>real civic need</strong> (while there are plenty of good ideas out there, we limit ourselves to civic tech related, social good projects). We realize this is a somewhat fuzzy distinction, which is why we always will have you discuss your problem statement/idea with Code for Dayton core team members before we commit to anything.</li>
 
-      <li>Due to our tie to Code for America, and the diverse group of our members, we may not be able to take on projects that are political in nature. Projects focused around things like open-data and transparency are fair game, but projects to support a partisan political effort are 'iffy' at best. (i.e transparency tool for campaign finance is good, website promoting a candidate is a no-go).</li>
+      <li>Due to our commitment to civic good and the diverse group of our members, we may not be able to take on projects that are political in nature. Projects focused around things like open-data and transparency are fair game, but projects to support a partisan political effort are 'iffy' at best. (i.e transparency tool for campaign finance is good, website promoting a candidate is a no-go).</li>
     </ol>
     <a class="btn-secondary btn--large" href="https://docs.google.com/forms/d/e/1FAIpQLScxqCYl8-fSx66u4d3A3G3UUYVcFXiYGv_xnm_Vir-Y9cTn4Q/viewform">Submit a project idea</a>
   </section>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This is a pretty standard [Jekyll](https://jekyllrb.com/) website at http://www.codefordayton.org/; there are a number of datasets in `_data` that build various lists displayed on the site. This site was **heavily** based on the website for [Code For Boston](https://www.codeforboston.org/).
 
-Please be sure to read our [Code of Conduct](http://www.codefordayton.org/code-of-conduct/). CFD is a [Code for America Brigade](http://www.codeforamerica.org/brigade/about).
+Please be sure to read our [Code of Conduct](http://www.codefordayton.org/code-of-conduct/). CFD is a local civic hacking group aligned with the [Alliance of Civic Technologists (ACT)](https://www.civictechnologists.org/).
 
 ## I want to build the website locally. How do I do that?
 


### PR DESCRIPTION
## Summary
- Updated all current references from Code for America Brigade to Alliance of Civic Technologists (ACT)
- Changed fiscal sponsor from Code for America Labs to Hack Club Bank
- Removed outdated Code for America documentation links
- Added CLAUDE.md file for future development guidance

## Files Changed
- `_config.yml` - Site description updated to reference ACT network
- `projects.html` - Replaced Code for America tie reference with commitment to civic good
- `readme.md` - Updated organizational description with ACT alignment  
- `privacy-policy.md` - Updated fiscal sponsor to Hack Club Bank
- `code-of-conduct.md` - Removed outdated Code for America documentation link
- `CLAUDE.md` - Added development guidance file

## Test plan
- [ ] Verify site builds successfully with Jekyll
- [ ] Review all updated pages for accuracy
- [ ] Confirm no broken links introduced

🤖 Generated with [Claude Code](https://claude.ai/code)