### PR TITLE
Add Toolbox page documenting civic tech tools and learning philosophy

### DIFF
--- a/toolbox.html
+++ b/toolbox.html
@@ -1,0 +1,143 @@
+---
+title: Toolbox
+permalink: "/toolbox/"
+layout: page
+type: inNavBar
+---
+
+<h1 class="t-section-headline">Building the Toolbox</h1>
+
+<div class="container">
+  <section class="intro">
+    <p>At Code for Dayton, we believe in "building the toolbox" - identifying the right tools to solve civic problems, developing capability with those tools, and using them consistently across projects. Our toolbox is always growing as we discover new technologies and approaches that help us create more effective solutions for our community.</p>
+    
+    <p>This page documents the tools we've found most valuable in our civic hacking work. Whether you're new to the group or a seasoned volunteer, this serves as a reference for the technologies we use and recommend.</p>
+    
+    <p><strong>Learning Together:</strong> One of our core goals is training people in relevant skills through civic service projects. We welcome diverse skillsets and experience levels - if there's something you want to learn, we'll try to find a place for you to develop that skill while contributing to meaningful community projects. Our civic tech work provides real-world learning opportunities where you can grow your abilities while making a positive impact.</p>
+  </section>
+
+  <section class="tool-category">
+    <h2>Development Tools</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>GitHub</h3>
+        <p>Version control and collaboration platform for all our code projects. Essential for managing contributions from multiple volunteers and maintaining project history.</p>
+        <a href="https://github.com/codefordayton" class="btn-secondary">Our GitHub</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Visual Studio Code</h3>
+        <p>Lightweight, extensible code editor with excellent support for web development, Python, and most languages we use in civic tech projects.</p>
+        <a href="https://code.visualstudio.com/" class="btn-secondary">Download</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Jekyll</h3>
+        <p>Static site generator (powers this website!) - great for creating documentation sites, project pages, and simple web applications.</p>
+        <a href="https://jekyllrb.com/" class="btn-secondary">Learn More</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="tool-category">
+    <h2>Data Analysis & Visualization</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>Python</h3>
+        <p>Versatile programming language excellent for data analysis, web scraping, and automation. Key libraries include pandas, matplotlib, and requests.</p>
+        <a href="https://python.org/" class="btn-secondary">Get Started</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Jupyter Notebooks</h3>
+        <p>Interactive computing environment perfect for data exploration, analysis, and sharing reproducible research with stakeholders.</p>
+        <a href="https://jupyter.org/" class="btn-secondary">Try Jupyter</a>
+      </div>
+      
+    </div>
+  </section>
+
+  <section class="tool-category">
+    <h2>Mapping & GIS</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>QGIS</h3>
+        <p>Open-source Geographic Information System for analyzing spatial data, creating maps, and understanding geographic patterns in civic data. <a href="/2023/05/03/qgis-plume.html">Read about our experience using QGIS for environmental contamination mapping</a>.</p>
+        <a href="https://qgis.org/" class="btn-secondary">Download</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Leaflet</h3>
+        <p>JavaScript library for interactive web maps. Lightweight and mobile-friendly, perfect for embedding maps in civic applications.</p>
+        <a href="https://leafletjs.com/" class="btn-secondary">Documentation</a>
+      </div>
+      
+    </div>
+  </section>
+
+  <section class="tool-category">
+    <h2>Communication & Collaboration</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>Discord</h3>
+        <p>Our primary communication platform for real-time chat, voice meetings, and project coordination.</p>
+        <a href="{{ site.discord_url }}" class="btn-secondary">Join Us</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Meetup</h3>
+        <p>Platform for organizing and promoting our regular meetings and events.</p>
+        <a href="{{ site.meetup_url }}" class="btn-secondary">Our Events</a>
+      </div>
+      
+    </div>
+  </section>
+
+  <section class="tool-category">
+    <h2>Project Management</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>GitHub Projects</h3>
+        <p>Integrated project management within GitHub for tracking issues, milestones, and project progress.</p>
+        <a href="https://github.com/features/project-management/" class="btn-secondary">Features</a>
+      </div>
+      
+    </div>
+  </section>
+
+  <section class="tool-category">
+    <h2>Infrastructure & Hosting</h2>
+    <div class="tool-list">
+      <div class="tool">
+        <h3>Digital Ocean</h3>
+        <p>Reliable cloud infrastructure for hosting applications and databases. We consistently return to Digital Ocean for its simplicity, predictable pricing, and excellent documentation.</p>
+        <a href="https://digitalocean.com/" class="btn-secondary">Learn More</a>
+      </div>
+      
+      <div class="tool">
+        <h3>GitHub Pages</h3>
+        <p>Free static site hosting directly from GitHub repositories. Perfect for project documentation, simple websites, and Jekyll sites like this one.</p>
+        <a href="https://pages.github.com/" class="btn-secondary">Get Started</a>
+      </div>
+      
+      <div class="tool">
+        <h3>Railway</h3>
+        <p>Modern platform for deploying applications with minimal configuration. Great for quickly prototyping and deploying civic tech solutions. Simple configuration for cron jobs makes it ideal for automated data collection and processing tasks.</p>
+        <a href="https://railway.app/" class="btn-secondary">Deploy Now</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="contribute">
+    <h2>Help Us Grow the Toolbox</h2>
+    <p>Found a tool that's been game-changing for civic tech work? We'd love to hear about it! Reach out to us on <a href="{{ site.discord_url }}">Discord</a> or <a href="mailto:{{ site.email }}">email</a> to suggest additions to our toolbox.</p>
+    
+    <p>We're particularly interested in tools that:</p>
+    <ul>
+      <li>Are open source or have generous free tiers</li>
+      <li>Have good documentation and learning resources</li>
+      <li>Scale well for volunteer-driven projects</li>
+      <li>Solve common civic tech challenges</li>
+    </ul>
+  </section>
+</div>


### PR DESCRIPTION
## Summary
- Added new Toolbox page to document our civic tech tools and "building the toolbox" philosophy
- Page automatically appears in header navigation and emphasizes skill development through civic service
- Organized tools by practical categories with links to documentation and real-world examples

## New Features
- **Toolbox Philosophy**: Explains our approach to identifying, learning, and consistently using civic tech tools
- **Learning Focus**: Emphasizes welcoming diverse skillsets and providing skill development opportunities
- **Tool Categories**: 
  - Development Tools (GitHub, VS Code, Jekyll)
  - Data Analysis & Visualization (Python, Jupyter)
  - Mapping & GIS (QGIS with link to contamination mapping blog post, Leaflet)
  - Communication & Collaboration (Discord, Meetup)
  - Infrastructure & Hosting (Digital Ocean, GitHub Pages, Railway)
  - Project Management (GitHub Projects)
- **Community Contribution**: Encourages suggestions for new tools

## Technical Details
- Uses existing page layout and styling patterns
- Accessible at `/toolbox/` with automatic header navigation via `type: inNavBar`
- Links to existing blog post demonstrating QGIS usage in real civic project
- Follows site's design conventions and responsive layout

## Test plan
- [ ] Verify page appears in header navigation
- [ ] Test all external links work correctly
- [ ] Confirm blog post link resolves properly
- [ ] Validate responsive design on mobile
- [ ] Check site builds successfully with Jekyll

🤖 Generated with [Claude Code](https://claude.ai/code)